### PR TITLE
Lower the precedence of services node attributes

### DIFF
--- a/providers/connection.rb
+++ b/providers/connection.rb
@@ -38,7 +38,7 @@ action :create do
   )
   exist = Mash.new(node['stunnel']['services'][new_resource.service_name])
   if(exist != hsh)
-    node.set['stunnel']['services'][new_resource.service_name] = hsh
+    node.default['stunnel']['services'][new_resource.service_name] = hsh
     new_resource.updated_by_last_action(true)
   end
 end
@@ -46,7 +46,7 @@ end
 action :delete do
   serv_data = Mash.new(node['stunnel']['services'])
   if(serv_data.delete(new_resource.service_name))
-    node.set['stunnel']['services'] = serv_data
+    node.default['stunnel']['services'] = serv_data
     new_resource.updated_by_last_action(true)
   end
 end


### PR DESCRIPTION
This makes services node attributes easier to manipulate via a wrapper cookbook and won't stick around with the node data long after this cookbook is gone from your stack.