### PR TITLE
Replacing restart on the configuration for reload 

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -59,7 +59,7 @@ template '/etc/stunnel/stunnel.conf' do
   source 'stunnel.conf.erb'
   mode 0644
   action :nothing
-  notifies :restart, 'service[stunnel]', :delayed
+  notifies :reload, 'service[stunnel]', :delayed
 end
 
 template '/etc/default/stunnel4' do


### PR DESCRIPTION
This short PR intends to replace the default restart behaviour for stunnel settings for reload. 

The idea behind this is that sending restart unanimously when the config template changes may interrupt sensitive connections and cause problems in different environments. Only chroot, foreground, pid, setgid and setuid settings require restart.
