### PR TITLE
Remove 'supports { manage_home: true }'

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,7 @@ user 'stunnel4' do
   home '/var/run/stunnel4'
   system true
   shell '/bin/false'
-  supports manage_home: true
+  manage_home true
   not_if { node['platform_family'] == 'debian' }
 end
 


### PR DESCRIPTION
It was removed in Chef-13: https://github.com/chef/chef/issues/5371